### PR TITLE
travis: correct `XENIMG`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS="-vv --net=socket"
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS-"-vv --net=direct"
-  - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen DEPLOY=1 XENIMG="decks.openmirage.org"
+  - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen DEPLOY=1 XENIMG="decks"
     UPDATE_GCC_BINUTILS=1
     FLAGS="-vv --net direct --dhcp false --network 0
            --ip 46.43.42.134 --netmask 255.255.255.128 --gateways 46.43.42.129"


### PR DESCRIPTION
I think this should fix the `DEPLOY=1` build failure following the merge of #71 ...
